### PR TITLE
Run flake8 tests to find syntax errors and undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+group: travis_latest
+language: python
+cache: pip
+python:
+    - 2.7
+    - 3.6
+    #- nightly
+    #- pypy
+    #- pypy3
+matrix:
+    allow_failures:
+        - python: nightly
+        - python: pypy
+        - python: pypy3
+install:
+    #- pip install -r requirements.txt
+    - pip install flake8  # pytest  # add another testing frameworks later
+before_script:
+    # stop the build if there are Python syntax errors or undefined names
+    - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+    - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+script:
+    - true  # pytest --capture=sys  # add other tests here
+notifications:
+    on_success: change
+    on_failure: change  # `always` will be the setting once code changes slow down


### PR DESCRIPTION
Every time someone submits a pull request, Travis Continuous Integration can automatically run tests on the code before it is reviewed.  Travis is always free to open source projects like this one but the owner of the this repo would need to go to https://travis-ci.org/profile and flip the repository switch on to enable testing.

flake8 testing of https://github.com/eriklindernoren/PyTorch-GAN on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./implementations/dragan/dragan.py:201:9: F821 undefined name 'd_'
        d_
        ^
./implementations/pix2pix/models.py:15:21: E999 SyntaxError: invalid syntax
        if normalize=:
                    ^
1     E999 SyntaxError: invalid syntax
1     F821 undefined name 'd_'
2
```

---

flake8 testing of https://github.com/eriklindernoren/Keras-GAN on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./gan/gan_rgb.py:204:50: E999 TabError: inconsistent use of tabs and spaces in indentation
	        d_loss_logs_f_a = np.array(d_loss_logs_f)
                                                 ^
1     E999 TabError: inconsistent use of tabs and spaces in indentation
1
```