### PR TITLE
Fixed the Missing Difinition of in_channels in bicyclegan/models.py

### DIFF
--- a/implementations/bicyclegan/models.py
+++ b/implementations/bicyclegan/models.py
@@ -150,7 +150,7 @@ class MultiDiscriminator(nn.Module):
                 ),
             )
 
-        self.downsample = nn.AvgPool2d(in_channels, stride=2, padding=[1, 1], count_include_pad=False)
+        self.downsample = nn.AvgPool2d(3, stride=2, padding=[1, 1], count_include_pad=False)
 
     def compute_loss(self, x, gt):
         """Computes the MSE between model output and scalar gt"""


### PR DESCRIPTION
According the original implementation, the stride of nn.AvgPool2d is 3. 
