### PR TITLE
ACGAN: remove softmax for aux_layer

### DIFF
--- a/implementations/acgan/acgan.py
+++ b/implementations/acgan/acgan.py
@@ -97,7 +97,7 @@ class Discriminator(nn.Module):
 
         # Output layers
         self.adv_layer = nn.Sequential(nn.Linear(128 * ds_size ** 2, 1), nn.Sigmoid())
-        self.aux_layer = nn.Sequential(nn.Linear(128 * ds_size ** 2, opt.n_classes), nn.Softmax())
+        self.aux_layer = nn.Linear(128 * ds_size ** 2, opt.n_classes)
 
     def forward(self, img):
         out = self.conv_blocks(img)


### PR DESCRIPTION
torch.nn.CrossEntropyLoss() does not need softmax activation.