### PR TITLE
Gpu selection + Tensorboard + Faster MNIST

### DIFF
--- a/data/optimized_MNIST.py
+++ b/data/optimized_MNIST.py
@@ -1,0 +1,30 @@
+import torch
+from torchvision.datasets import MNIST
+
+device = torch.device('cuda')
+
+
+class FastMNIST(MNIST):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Scale data to [0,1]
+        self.data = self.data.unsqueeze(1).float().div(255)
+
+        # Normalize it with the usual MNIST mean and std
+        self.data = self.data.sub_(0.1307).div_(0.3081)
+
+        # Put both data and targets on GPU in advance
+        self.data, self.targets = self.data.to(device), self.targets.to(device)
+
+    def __getitem__(self, index):
+        """
+        Args:
+            index (int): Index
+
+        Returns:
+            tuple: (image, target) where target is index of the target class.
+        """
+        img, target = self.data[index], self.targets[index]
+
+        return img, target

--- a/implementations/cgan/cgan.py
+++ b/implementations/cgan/cgan.py
@@ -3,12 +3,14 @@ import os
 import numpy as np
 import math
 
+import torchvision
 import torchvision.transforms as transforms
 from torchvision.utils import save_image
 
 from torch.utils.data import DataLoader
 from torchvision import datasets
 from torch.autograd import Variable
+from torch.utils.tensorboard import SummaryWriter
 
 import torch.nn as nn
 import torch.nn.functional as F
@@ -130,6 +132,11 @@ optimizer_D = torch.optim.Adam(discriminator.parameters(), lr=opt.lr, betas=(opt
 FloatTensor = torch.cuda.FloatTensor if cuda else torch.FloatTensor
 LongTensor = torch.cuda.LongTensor if cuda else torch.LongTensor
 
+writer = SummaryWriter()
+save_folder = 'results/'+list(writer.all_writers.keys())[0]
+os.makedirs(save_folder)
+if len(os.listdir(save_folder)) is not 0:
+    raise Exception('Directory is not empty!')
 
 def sample_image(n_row, batches_done):
     """Saves a grid of generated digits ranging from 0 to n_classes"""
@@ -139,7 +146,7 @@ def sample_image(n_row, batches_done):
     labels = np.array([num for _ in range(n_row) for num in range(n_row)])
     labels = Variable(LongTensor(labels))
     gen_imgs = generator(z, labels)
-    save_image(gen_imgs.data, "images/%d.png" % batches_done, nrow=n_row, normalize=True)
+    save_image(gen_imgs.data, save_folder+"/%d.png" % batches_done, nrow=n_row, normalize=True)
 
 
 # ----------
@@ -147,6 +154,8 @@ def sample_image(n_row, batches_done):
 # ----------
 
 for epoch in range(opt.n_epochs):
+    g_loss_epoch = 0
+    d_loss_epoch = 0
     for i, (imgs, labels) in enumerate(dataloader):
 
         batch_size = imgs.shape[0]
@@ -199,6 +208,9 @@ for epoch in range(opt.n_epochs):
         d_loss.backward()
         optimizer_D.step()
 
+        g_loss_epoch += g_loss.item() / len(dataloader)
+        d_loss_epoch += d_loss.item() / len(dataloader)
+
         print(
             "[Epoch %d/%d] [Batch %d/%d] [D loss: %f] [G loss: %f]"
             % (epoch, opt.n_epochs, i, len(dataloader), d_loss.item(), g_loss.item())
@@ -207,3 +219,7 @@ for epoch in range(opt.n_epochs):
         batches_done = epoch * len(dataloader) + i
         if batches_done % opt.sample_interval == 0:
             sample_image(n_row=10, batches_done=batches_done)
+    writer.add_scalar('Loss/generator', g_loss_epoch, epoch)
+    writer.add_scalar('Loss/discriminator', d_loss_epoch, epoch)
+    img_grid = torchvision.utils.make_grid(gen_imgs.data[:25])
+    writer.add_image('Sample generated images', img_grid, epoch)

--- a/implementations/cgan/cgan.py
+++ b/implementations/cgan/cgan.py
@@ -12,6 +12,8 @@ from torchvision import datasets
 from torch.autograd import Variable
 from torch.utils.tensorboard import SummaryWriter
 
+from data import optimized_MNIST
+
 import torch.nn as nn
 import torch.nn.functional as F
 import torch
@@ -110,20 +112,33 @@ if cuda:
 else:
     print("using CPU")
 
+
 # Configure data loader
-os.makedirs("../../data/mnist", exist_ok=True)
-dataloader = torch.utils.data.DataLoader(
-    datasets.MNIST(
-        "../../data/mnist",
-        train=True,
-        download=True,
-        transform=transforms.Compose(
-            [transforms.Resize(opt.img_size), transforms.ToTensor(), transforms.Normalize([0.5], [0.5])]
+if opt.img_size == 28:
+    print("using optimized MNIST dataset")
+    dataloader = torch.utils.data.DataLoader(
+        optimized_MNIST.FastMNIST(
+            "../../data/mnist",
+            train=True,
+            download=True,
         ),
-    ),
-    batch_size=opt.batch_size,
-    shuffle=True,
-)
+        batch_size=opt.batch_size,
+        shuffle=True,
+    )
+else:
+    os.makedirs("../../data/mnist", exist_ok=True)
+    dataloader = torch.utils.data.DataLoader(
+        datasets.MNIST(
+            "../../data/mnist",
+            train=True,
+            download=True,
+            transform=transforms.Compose(
+                [transforms.Resize(opt.img_size), transforms.ToTensor(), transforms.Normalize([0.5], [0.5])]
+            ),
+        ),
+        batch_size=opt.batch_size,
+        shuffle=True,
+    )
 
 # Optimizers
 optimizer_G = torch.optim.Adam(generator.parameters(), lr=opt.lr, betas=(opt.b1, opt.b2))

--- a/implementations/cgan/cgan.py
+++ b/implementations/cgan/cgan.py
@@ -28,6 +28,7 @@ parser.add_argument("--n_classes", type=int, default=10, help="number of classes
 parser.add_argument("--img_size", type=int, default=32, help="size of each image dimension")
 parser.add_argument("--channels", type=int, default=1, help="number of image channels")
 parser.add_argument("--sample_interval", type=int, default=400, help="interval between image sampling")
+parser.add_argument("--gpu", type=int, default=0, help="interval betwen image samples")
 opt = parser.parse_args()
 print(opt)
 
@@ -99,9 +100,13 @@ generator = Generator()
 discriminator = Discriminator()
 
 if cuda:
+    torch.cuda.set_device(opt.gpu)
+    print("using GPU " + str(opt.gpu) + ": " + torch.cuda.get_device_name(opt.gpu))
     generator.cuda()
     discriminator.cuda()
     adversarial_loss.cuda()
+else:
+    print("using CPU")
 
 # Configure data loader
 os.makedirs("../../data/mnist", exist_ok=True)

--- a/implementations/gan/gan.py
+++ b/implementations/gan/gan.py
@@ -27,6 +27,7 @@ parser.add_argument("--latent_dim", type=int, default=100, help="dimensionality 
 parser.add_argument("--img_size", type=int, default=28, help="size of each image dimension")
 parser.add_argument("--channels", type=int, default=1, help="number of image channels")
 parser.add_argument("--sample_interval", type=int, default=400, help="interval betwen image samples")
+parser.add_argument("--gpu", type=int, default=0, help="interval betwen image samples")
 opt = parser.parse_args()
 print(opt)
 
@@ -89,9 +90,13 @@ generator = Generator()
 discriminator = Discriminator()
 
 if cuda:
+    torch.cuda.set_device(opt.gpu)
+    print("using GPU " + str(opt.gpu) + ": " + torch.cuda.get_device_name(opt.gpu))
     generator.cuda()
     discriminator.cuda()
     adversarial_loss.cuda()
+else:
+    print("using CPU")
 
 # Configure data loader
 os.makedirs("../../data/mnist", exist_ok=True)

--- a/implementations/gan/gan.py
+++ b/implementations/gan/gan.py
@@ -11,7 +11,8 @@ from torch.utils.data import DataLoader
 from torchvision import datasets
 from torch.autograd import Variable
 from torch.utils.tensorboard import SummaryWriter
-from tensorboard import program
+
+from data import optimized_MNIST
 
 import torch.nn as nn
 import torch.nn.functional as F
@@ -102,19 +103,32 @@ else:
     print("using CPU")
 
 # Configure data loader
-os.makedirs("../../data/mnist", exist_ok=True)
-dataloader = torch.utils.data.DataLoader(
-    datasets.MNIST(
-        "../../data/mnist",
-        train=True,
-        download=True,
-        transform=transforms.Compose(
-            [transforms.Resize(opt.img_size), transforms.ToTensor(), transforms.Normalize([0.5], [0.5])]
+if opt.img_size == 28:
+    print("using optimized MNIST dataset")
+    dataloader = torch.utils.data.DataLoader(
+        optimized_MNIST.FastMNIST(
+            "../../data/mnist",
+            train=True,
+            download=True,
         ),
-    ),
-    batch_size=opt.batch_size,
-    shuffle=True,
-)
+        batch_size=opt.batch_size,
+        shuffle=True,
+    )
+else:
+    os.makedirs("../../data/mnist", exist_ok=True)
+    dataloader = torch.utils.data.DataLoader(
+        datasets.MNIST(
+            "../../data/mnist",
+            train=True,
+            download=True,
+            transform=transforms.Compose(
+                [transforms.Resize(opt.img_size), transforms.ToTensor(), transforms.Normalize([0.5], [0.5])]
+            ),
+        ),
+        batch_size=opt.batch_size,
+        shuffle=True,
+    )
+
 
 # Optimizers
 optimizer_G = torch.optim.Adam(generator.parameters(), lr=opt.lr, betas=(opt.b1, opt.b2))

--- a/implementations/gan/gan.py
+++ b/implementations/gan/gan.py
@@ -98,6 +98,22 @@ if cuda:
 else:
     print("using CPU")
 
+if os.path.isdir('images'):
+    expand = 0
+    while True:
+        expand += 1
+        save_folder = 'images' + '({})'.format(expand)
+        if os.path.isdir(save_folder):
+            continue
+        else:
+            os.makedirs(save_folder)
+            break
+else:
+    save_folder = 'images'
+    os.makedirs(save_folder)
+if len(os.listdir(save_folder)) is not 0:
+    raise Exception('Directory is not empty!')
+
 # Configure data loader
 os.makedirs("../../data/mnist", exist_ok=True)
 dataloader = torch.utils.data.DataLoader(
@@ -172,4 +188,4 @@ for epoch in range(opt.n_epochs):
 
         batches_done = epoch * len(dataloader) + i
         if batches_done % opt.sample_interval == 0:
-            save_image(gen_imgs.data[:25], "images/%d.png" % batches_done, nrow=5, normalize=True)
+            save_image(gen_imgs.data[:25], save_folder+"/%d.png" % batches_done, nrow=5, normalize=True)

--- a/implementations/gan/gan.py
+++ b/implementations/gan/gan.py
@@ -191,4 +191,4 @@ for epoch in range(opt.n_epochs):
     writer.add_scalar('Loss/generator', g_loss_epoch, epoch)
     writer.add_scalar('Loss/discriminator', d_loss_epoch, epoch)
     img_grid = torchvision.utils.make_grid(gen_imgs.data[:25])
-    writer.add_image('Sample generated images', img_grid)
+    writer.add_image('Sample generated images', img_grid, epoch)

--- a/implementations/gan/gan.py
+++ b/implementations/gan/gan.py
@@ -3,12 +3,15 @@ import os
 import numpy as np
 import math
 
+import torchvision
 import torchvision.transforms as transforms
 from torchvision.utils import save_image
 
 from torch.utils.data import DataLoader
 from torchvision import datasets
 from torch.autograd import Variable
+from torch.utils.tensorboard import SummaryWriter
+from tensorboard import program
 
 import torch.nn as nn
 import torch.nn.functional as F
@@ -98,22 +101,6 @@ if cuda:
 else:
     print("using CPU")
 
-if os.path.isdir('images'):
-    expand = 0
-    while True:
-        expand += 1
-        save_folder = 'images' + '({})'.format(expand)
-        if os.path.isdir(save_folder):
-            continue
-        else:
-            os.makedirs(save_folder)
-            break
-else:
-    save_folder = 'images'
-    os.makedirs(save_folder)
-if len(os.listdir(save_folder)) is not 0:
-    raise Exception('Directory is not empty!')
-
 # Configure data loader
 os.makedirs("../../data/mnist", exist_ok=True)
 dataloader = torch.utils.data.DataLoader(
@@ -135,11 +122,20 @@ optimizer_D = torch.optim.Adam(discriminator.parameters(), lr=opt.lr, betas=(opt
 
 Tensor = torch.cuda.FloatTensor if cuda else torch.FloatTensor
 
+writer = SummaryWriter()
+save_folder = 'results/'+list(writer.all_writers.keys())[0]
+os.makedirs(save_folder)
+if len(os.listdir(save_folder)) is not 0:
+    raise Exception('Directory is not empty!')
+
+
 # ----------
 #  Training
 # ----------
 
 for epoch in range(opt.n_epochs):
+    g_loss_epoch = 0
+    d_loss_epoch = 0
     for i, (imgs, _) in enumerate(dataloader):
 
         # Adversarial ground truths
@@ -181,6 +177,8 @@ for epoch in range(opt.n_epochs):
         d_loss.backward()
         optimizer_D.step()
 
+        g_loss_epoch += g_loss.item() / len(dataloader)
+        d_loss_epoch += d_loss.item() / len(dataloader)
         print(
             "[Epoch %d/%d] [Batch %d/%d] [D loss: %f] [G loss: %f]"
             % (epoch, opt.n_epochs, i, len(dataloader), d_loss.item(), g_loss.item())
@@ -189,3 +187,8 @@ for epoch in range(opt.n_epochs):
         batches_done = epoch * len(dataloader) + i
         if batches_done % opt.sample_interval == 0:
             save_image(gen_imgs.data[:25], save_folder+"/%d.png" % batches_done, nrow=5, normalize=True)
+
+    writer.add_scalar('Loss/generator', g_loss_epoch, epoch)
+    writer.add_scalar('Loss/discriminator', d_loss_epoch, epoch)
+    img_grid = torchvision.utils.make_grid(gen_imgs.data[:25])
+    writer.add_image('Sample generated images', img_grid)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 torch>=0.4.0
-torchvision
+torchvision~=0.5.0
 matplotlib
-numpy
-scipy
-pillow
+numpy~=1.18.1
+scipy~=1.4.1
+pillow~=7.0.0
 urllib3
 scikit-image
+tensorboard~=2.1.0


### PR DESCRIPTION
Hello there,

First of all thanks for your amazing work on gans.
you made them really easy to understand for newbies.

I added a few things to gan.py and cgan.py (which are the only ones I've used so far) :

- allow to select which gpu to use with a command line argument "--gpu" 0, 1 or 2 etc.
- tensorboard visualisation of G and D losses
- improved version of the MNIST dataset class which I found here : https://gist.github.com/y0ast/f69966e308e549f013a92dc66debeeb 4.
It bypasses the image resizing which converts the image to PIL object and is slow..
It's only enabled when setting im_size 28 then (original MNIST size).
I've seen great improvements (x2 speed)

If you want I can also make those changes to the other gans

Cheers.

