### PR TITLE
modify VGG19 feature map layer in srgan

### DIFF
--- a/implementations/srgan/models.py
+++ b/implementations/srgan/models.py
@@ -9,7 +9,7 @@ class FeatureExtractor(nn.Module):
     def __init__(self):
         super(FeatureExtractor, self).__init__()
         vgg19_model = vgg19(pretrained=True)
-        self.feature_extractor = nn.Sequential(*list(vgg19_model.features.children())[:18])
+        self.feature_extractor = nn.Sequential(*list(vgg19_model.features.children())[:35])
 
     def forward(self, img):
         return self.feature_extractor(img)

--- a/implementations/srgan/models.py
+++ b/implementations/srgan/models.py
@@ -59,7 +59,7 @@ class GeneratorResNet(nn.Module):
         self.upsampling = nn.Sequential(*upsampling)
 
         # Final output layer
-        self.conv3 = nn.Sequential(nn.Conv2d(64, out_channels, kernel_size=9, stride=1, padding=4), nn.Tanh())
+        self.conv3 = nn.Conv2d(64, out_channels, kernel_size=9, stride=1, padding=4)
 
     def forward(self, x):
         out1 = self.conv1(x)


### PR DESCRIPTION
The final srgan in its paper uses the feature map obtained by the 4-th convolution (after activation) before the 5-th maxpooling layer within the VGG19 network.

Also no tanh at the end of conv3 for the generator, just a convolution