### PR TITLE
RGAN: Fix nonsense code and stick to original paper

### DIFF
--- a/implementations/relativistic_gan/relativistic_gan.py
+++ b/implementations/relativistic_gan/relativistic_gan.py
@@ -147,7 +147,7 @@ for epoch in range(opt.n_epochs):
 
         # Predict validity
         real_pred = discriminator(real_imgs)
-        fake_pred = discriminator(gen_imgs.detach())
+        fake_pred = discriminator(gen_imgs).detach()
 
         if opt.rel_avg_gan:
             real_loss = adversarial_loss(real_pred - fake_pred.mean(0, keepdim=True), valid)

--- a/implementations/relativistic_gan/relativistic_gan.py
+++ b/implementations/relativistic_gan/relativistic_gan.py
@@ -133,31 +133,11 @@ for epoch in range(opt.n_epochs):
         # Configure input
         real_imgs = Variable(imgs.type(Tensor))
 
-        # -----------------
-        #  Train Generator
-        # -----------------
-
-        optimizer_G.zero_grad()
-
         # Sample noise as generator input
         z = Variable(Tensor(np.random.normal(0, 1, (imgs.shape[0], opt.latent_dim))))
 
         # Generate a batch of images
         gen_imgs = generator(z)
-
-        real_pred = discriminator(real_imgs).detach()
-        fake_pred = discriminator(gen_imgs)
-
-        if opt.rel_avg_gan:
-            g_loss = adversarial_loss(fake_pred - real_pred.mean(0, keepdim=True), valid)
-        else:
-            g_loss = adversarial_loss(fake_pred - real_pred, valid)
-
-        # Loss measures generator's ability to fool the discriminator
-        g_loss = adversarial_loss(discriminator(gen_imgs), valid)
-
-        g_loss.backward()
-        optimizer_G.step()
 
         # ---------------------
         #  Train Discriminator
@@ -172,14 +152,32 @@ for epoch in range(opt.n_epochs):
         if opt.rel_avg_gan:
             real_loss = adversarial_loss(real_pred - fake_pred.mean(0, keepdim=True), valid)
             fake_loss = adversarial_loss(fake_pred - real_pred.mean(0, keepdim=True), fake)
+            d_loss = (real_loss + fake_loss) / 2
         else:
-            real_loss = adversarial_loss(real_pred - fake_pred, valid)
-            fake_loss = adversarial_loss(fake_pred - real_pred, fake)
-
-        d_loss = (real_loss + fake_loss) / 2
+            d_loss = adversarial_loss(real_pred - fake_pred, valid)
 
         d_loss.backward()
         optimizer_D.step()
+        
+        # -----------------
+        #  Train Generator
+        # -----------------
+
+        optimizer_G.zero_grad()
+
+        real_pred = discriminator(real_imgs).detach()
+        fake_pred = discriminator(gen_imgs)
+
+        # Loss measures generator's ability to fool the discriminator
+        if opt.rel_avg_gan:
+            real_loss = adversarial_loss(real_pred - fake_pred.mean(0, keepdim=True), fake)
+            fake_loss = adversarial_loss(fake_pred - real_pred.mean(0, keepdim=True), valid)
+            g_loss = (real_loss + fake_loss) / 2
+        else:
+            g_loss = adversarial_loss(fake_pred - real_pred, valid)
+
+        g_loss.backward()
+        optimizer_G.step()
 
         print(
             "[Epoch %d/%d] [Batch %d/%d] [D loss: %f] [G loss: %f]"


### PR DESCRIPTION
Fix nonsense code in the training code: 
<https://github.com/eriklindernoren/PyTorch-GAN/blob/36d3c77e5ff20ebe0aeefd322326a134a279b93e/implementations/relativistic_gan/relativistic_gan.py#L151-L157>  
As shown above, `g_loss` is assigned and then immediately overwritten, which makes no sense.  

Adjustments to better stick to the original paper: 
 - Update discriminator before generator instead of the opposite
 - Revamp loss calculation code (see below)

According to the paper, for RGAN:  
![1727357458440](https://github.com/user-attachments/assets/441029a8-fa64-4be1-b1be-3f94e5a246a7)

For RaGAN:  
![1727357305323](https://github.com/user-attachments/assets/5a4d630e-c01c-48aa-851f-aafe417f9fe9)

Implementation reference:  
<https://github.com/AlexiaJM/RelativisticGAN/blob/master/code/GAN_losses_iter.py#L636-L639>
